### PR TITLE
Chore/project default target settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,38 +55,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the build type" FORCE)
 endif()
 
-# compiler options:
-
-if(MSVC)
-  add_compile_options(
-    # warnings:
-    /W4 /w14545 /w34242 /w34254 /w34287 /w44263 /w44265  /w44296 /w44311 /w44826
-    /we4289 /w14546 /w14547 /w14549 /w14555 /w14619 /w14905 /w14906 /w14928
-
-    # optimization levels:
-    $<$<CONFIG:RELEASE>:/O2>
-    $<$<CONFIG:DEBUG>:/Od>
-  )
-else()
-  add_compile_options(
-    # warnings:
-    -Wall -Wconversion -Wsign-conversion -Wshadow -Wnon-virtual-dtor -Wcast-qual
-    -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -pedantic -Wextra
-
-    # optimization levels:
-    $<$<CONFIG:RELEASE>:-O3>
-    $<$<CONFIG:DEBUG>:-O0>
-
-    # coverage:
-    $<$<BOOL:${CODE_COVERAGE}>:-coverage>
-  )
-
-  add_link_options(
-    # coverage:
-    $<$<BOOL:${CODE_COVERAGE}>:-coverage>
-  )
-endif()
-
 # testing:
 
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,18 @@ project(
   LANGUAGES    CXX
 )
 
-# modules:
 
+# cmake modules and scripts:
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# custom modules:
+include(DefaultTargetSettings)
+
+# standard/built-in modules:
 include(CMakeDependentOption)
 include(FetchContent)
+
 
 # project options:
 

--- a/app-command-line/CMakeLists.txt
+++ b/app-command-line/CMakeLists.txt
@@ -2,15 +2,8 @@
 
 add_executable(hasm src/main.cpp)
 
-target_compile_features(hasm PUBLIC cxx_std_20)
-
-set_target_properties(
-  hasm
-  PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    COMPILE_WARNING_AS_ERROR ON
-)
+apply_target_options(hasm)
+apply_target_warnings(hasm)
 
 target_link_libraries(
   hasm

--- a/cmake/DefaultTargetSettings.cmake
+++ b/cmake/DefaultTargetSettings.cmake
@@ -1,0 +1,187 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# Prevent double inclusion
+
+include_guard(GLOBAL)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# 'target_options'
+#
+# Default compiler and linker settings shared by every target in the project.
+#
+# Includes:
+#   - Required C++ standard
+#   - Compiler conformance settings
+
+add_library(default_target_options INTERFACE)
+
+# C++ language configuration:
+target_compile_features(default_target_options INTERFACE cxx_std_20)
+
+set_target_properties(default_target_options
+    PROPERTIES
+        INTERFACE_CXX_STANDARD_REQUIRED ON
+        INTERFACE_CXX_EXTENSIONS        OFF
+)
+
+# Compiler configuration:
+
+target_compile_options(default_target_options INTERFACE
+    # MSVC
+    $<$<CXX_COMPILER_ID:MSVC>:
+    /permissive-     # Enforce strict standard C++ conformity (Disables legacy MSVC workarounds)
+    /Zc:__cplusplus  # Force MSVC (__cplusplus macro) to report  the chosen C++20 standard value.
+                     # See (https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus)
+    /Zc:inline       # Removes unreferenced inline functions from object files. This can Speed up compilation
+                     # and reduce binary size.
+    >
+)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# 'target_warnings'
+#
+# Default warning policy shared by every target in the project.
+#
+# Includes:
+#   - Warning level
+#   - Warnings as errors
+#   - Extra diagnostics
+
+add_library(default_target_warnings INTERFACE)
+
+target_compile_options(default_target_warnings INTERFACE
+    # MSVC (Windows) flags:
+    $<$<CXX_COMPILER_ID:MSVC>:
+    /W4     # Warning level 4 (Production standard, very strict)
+    /WX     # Treat warnings as errors
+    /w14545 # Function behavior change
+    /w34242 # Possible data loss
+    /w34254 # Narrowing conversion
+    /w34287 # Unsigned/negative mismatch
+    /w44263 # No virtual destructor
+    /w44265 # Class has virtual functions but destructor isn't virtual
+    /w44296 # Expression is always true/false
+    /w44311 # Pointer truncation
+    /w44826 # Conversion is sign-extended
+    /we4289 # Treat loop-control misuse as error
+    >
+
+    # GCC / Clang flags:
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
+    -Wall                # Enable common warnings
+    -Werror              # Treat warnings as errors
+    -Wpedantic           # Enforce strict ISO C++
+    -Wshadow             # Detect variable shadowing
+    -Wunused             # Detect unused variables/functions
+    -Wconversion         # Warn about implicit narrowing conversions
+    -Wsign-conversion    # Warn about signed/unsigned conversions
+    -Wnon-virtual-dtor   # Warn about polymorphic classes without virtual destructor
+    -Wcast-qual          # Warn when const qualifiers are discarded
+    -Wold-style-cast     # Warn about C-style casts
+    -Wcast-align         # Warn about alignment-changing casts
+    -Woverloaded-virtual # Warn about hidden virtual functions
+    >
+)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# 'default_target_coverage'
+#
+# Code coverage instrumentation.
+#
+# Enabled only when CODE_COVERAGE is ON.
+#
+
+add_library(default_target_coverage INTERFACE)
+
+target_compile_options(default_target_coverage INTERFACE
+    $<$<BOOL:${CODE_COVERAGE}>:
+    -coverage # Enable gcov/llvm-cov instrumentation
+    >
+)
+
+target_link_options(default_target_coverage INTERFACE
+    $<$<BOOL:${CODE_COVERAGE}>:
+    -coverage # Link coverage runtime
+    >
+)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Public API
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Applies the project's default compiler and build configuration to a target.
+#
+# This function configures the target with the project's standard build settings,
+# including:
+#
+#   - Required C++ language standard
+#   - Compiler conformance options
+#   - Link-Time Optimization (when supported)
+#
+# Call this once for every target built by the project.
+#
+function(apply_target_options target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "apply_target_options(): '${target}' is not a CMake target.")
+    endif()
+
+    get_target_property(type ${target} TYPE)
+
+    if(type STREQUAL "INTERFACE_LIBRARY")
+        set(scope INTERFACE)
+    else()
+        set(scope PRIVATE)
+    endif()
+
+    target_link_libraries(${target} ${scope} default_target_options)
+endfunction()
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Applies the project's default compiler warning policy to a target.
+#
+# This function enables the project's standard warning level and treats warnings
+# as errors. The exact warning flags are selected automatically based on the
+# active compiler.
+#
+# Call this once for every target built by the project.
+#
+function(apply_target_warnings target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "apply_target_warnings(): '${target}' is not a CMake target.")
+    endif()
+
+    get_target_property(type ${target} TYPE)
+
+    if(type STREQUAL "INTERFACE_LIBRARY")
+        set(scope INTERFACE)
+    else()
+        set(scope PRIVATE)
+    endif()
+
+    target_link_libraries(${target} ${scope} default_target_warnings)
+endfunction()
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Applies code coverage instrumentation to a target.
+#
+# This function configures compiler and linker flags required to generate coverage
+# metrics (e.g., GCC/Clang gcov flags or MSVC coverage flags) for debug builds.
+#
+# Call this for executable or test targets where coverage tracking is required.
+#
+# Note: Ensure the build type supports instrumentation (typically Debug or RelWithDebInfo).
+#
+function(apply_target_coverage target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "apply_target_coverage(): '${target}' is not a CMake target.")
+    endif()
+
+    get_target_property(type ${target} TYPE)
+
+    if(type STREQUAL "INTERFACE_LIBRARY")
+        set(scope INTERFACE)
+    else()
+        set(scope PRIVATE)
+    endif()
+
+    target_link_libraries(${target} ${scope} default_target_coverage)
+endfunction()

--- a/hack/CMakeLists.txt
+++ b/hack/CMakeLists.txt
@@ -8,15 +8,9 @@ add_library(
   include/Hack/Word.hpp
 )
 
-target_compile_features(hack INTERFACE cxx_std_20)
-
-set_target_properties(
-  hack
-  PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    COMPILE_WARNING_AS_ERROR ON
-)
+apply_target_options(hack)
+apply_target_warnings(hack)
+apply_target_coverage(hack)
 
 target_include_directories(
   hack

--- a/hasm/CMakeLists.txt
+++ b/hasm/CMakeLists.txt
@@ -25,15 +25,9 @@ add_library(
   src/hasm/SymbolTableWriter.cpp
 )
 
-target_compile_features(hack_assembler PUBLIC cxx_std_20)
-
-set_target_properties(
-  hack_assembler
-  PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    COMPILE_WARNING_AS_ERROR ON
-)
+apply_target_options(hack_assembler)
+apply_target_warnings(hack_assembler)
+apply_target_coverage(hack_assembler)
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/hasm/HasmInfo.hpp.in

--- a/hasm/tests/CMakeLists.txt
+++ b/hasm/tests/CMakeLists.txt
@@ -10,15 +10,9 @@ add_executable(
   src/SymbolTable.test.cpp
 )
 
-target_compile_features(hasm_assembler_tests PUBLIC cxx_std_20)
-
-set_target_properties(
-  hasm_assembler_tests
-  PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    COMPILE_WARNING_AS_ERROR ON
-)
+apply_target_options(hasm_assembler_tests)
+apply_target_warnings(hasm_assembler_tests)
+apply_target_coverage(hasm_assembler_tests)
 
 target_link_libraries(
   hasm_assembler_tests

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -7,15 +7,9 @@ add_library(
   src/utilities/CommandLineParser.cpp
 )
 
-target_compile_features(utilities PUBLIC cxx_std_20)
-
-set_target_properties(
-  utilities
-  PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    COMPILE_WARNING_AS_ERROR ON
-)
+apply_target_options(utilities)
+apply_target_warnings(utilities)
+apply_target_coverage(utilities)
 
 target_include_directories(utilities PUBLIC include)
 

--- a/utilities/tests/CMakeLists.txt
+++ b/utilities/tests/CMakeLists.txt
@@ -3,15 +3,9 @@ add_executable(
   src/CommandLineParser.test.cpp
 )
 
-target_compile_features(utilities_tests PUBLIC cxx_std_20)
-
-set_target_properties(
-  utilities_tests
-  PROPERTIES
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS OFF
-    COMPILE_WARNING_AS_ERROR ON
-)
+apply_target_options(utilities_tests)
+apply_target_warnings(utilities_tests)
+apply_target_coverage(utilities_tests)
 
 target_link_libraries(
   utilities_tests


### PR DESCRIPTION
### Changes

Adding `DefaultTargetSettings.cmake` to define projects build options, warnings and setups. We drop the global setup of those settings and work on a CMake-target level now.