### PR TITLE
Fix/failing macOS build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Failing macOS build: bump CLI11 to v2.6.2
 - Coverity Scan issues
 - CMake warnings
 - Illegal memory access in assembler engine

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ cmake_dependent_option(CODE_COVERAGE "Enable code coverage" OFF "BUILD_TESTS" OF
 FetchContent_Declare(
   cli11_proj
   GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
-  GIT_TAG        v2.3.2
+  GIT_TAG        v2.6.2
 )
 
 FetchContent_MakeAvailable(cli11_proj)

--- a/utilities/src/utilities/CommandLineParser.cpp
+++ b/utilities/src/utilities/CommandLineParser.cpp
@@ -11,11 +11,11 @@ Utilities::CommandLineParser::Result createCLIAndParse( const int argc, char con
 {
     CLI::App app{ "hasm: assembler for the nand2tetris hack platform" };
 
-    std::filesystem::path inputFile{};
+    std::filesystem::path inputFile;
 
-    const auto inputFileOption = app.add_option( "-i,--input-file", inputFile, "input .asm file" );
+    auto* inputFileOption = app.add_option( "-i,--input-file", inputFile, "input .asm file" );
 
-    bool exportSymbolTable{ false };
+    bool exportSymbolTable = false;
 
     app.add_flag( "-s,--symbol-table", exportSymbolTable, "export symbol table (to <input file>.sym)" )
         ->needs( inputFileOption );


### PR DESCRIPTION
### Changes

GitHub action CI was failing for macOS builds due to CLI11 v2.3.2 requiring an old CMake version. Bumping to v2.6.2 fixes the problem.