### PR TITLE
Chore/hasm gui infrastructure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: 6.9.1
+          cache: true
+
       - name: Create build directory
         run: cmake -E make_directory ${{github.workspace}}/build
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: 6.9.1
+          cache: true
+
       - name: Install dependencies
         run: sudo apt-get install -o Acquire::Retries=3 lcov
 

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -12,6 +12,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: 6.9.1
+          cache: true
+
       - name: Create build directory
         run: cmake -E make_directory ${{github.workspace}}/build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Qt/Qml infrastructure for new `hasm-gui`
 - Support user-defined output paths
 - GitHub pull request template
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include(CMakeDependentOption)
 # Project options:
 
 option(BUILD_HASM_CLI "Build the hasm command-line application" ON)
+option(BUILD_HASM_GUI "Build the hasm GUI application" ON)
 option(BUILD_TESTS "Build the project's test suite" ON)
 cmake_dependent_option(CODE_COVERAGE "Enable code coverage" OFF "BUILD_TESTS" OFF)
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,3 +1,7 @@
 if(BUILD_HASM_CLI)
     add_subdirectory(hasm-cli)
 endif()
+
+if(BUILD_HASM_GUI)
+    add_subdirectory(hasm-gui)
+endif()

--- a/apps/hasm-cli/src/main.cpp
+++ b/apps/hasm-cli/src/main.cpp
@@ -51,7 +51,7 @@ struct RequestVisitor
 
 } // namespace
 
-int main( const int argc, char** argv )
+int main( const int argc, char* argv[] )
 {
     const auto userRequest = CommandLineParser::parse( argc, argv );
 

--- a/apps/hasm-gui/CMakeLists.txt
+++ b/apps/hasm-gui/CMakeLists.txt
@@ -1,0 +1,26 @@
+# External dependencies:
+
+find_package(Qt6 REQUIRED COMPONENTS Gui)
+
+qt_standard_project_setup(REQUIRES 6.9)
+
+
+# Executable:
+
+qt_add_executable(hasm-gui)
+
+apply_target_options(hasm-gui)
+apply_target_warnings(hasm-gui)
+
+target_sources(hasm-gui
+    PRIVATE
+        src/main.cpp
+)
+
+
+# Dependencies:
+
+target_link_libraries(hasm-gui
+    PRIVATE
+        Qt6::Gui
+)

--- a/apps/hasm-gui/CMakeLists.txt
+++ b/apps/hasm-gui/CMakeLists.txt
@@ -1,6 +1,10 @@
 # External dependencies:
 
-find_package(Qt6 REQUIRED COMPONENTS Gui)
+find_package(Qt6 REQUIRED
+    COMPONENTS
+        Quick
+        QuickControls2
+)
 
 qt_standard_project_setup(REQUIRES 6.9)
 
@@ -17,10 +21,18 @@ target_sources(hasm-gui
         src/main.cpp
 )
 
+qt_add_qml_module(hasm-gui
+    URI     Hasm
+    VERSION 1.0
+    QML_FILES
+        src/qml/Main.qml
+)
+
 
 # Dependencies:
 
 target_link_libraries(hasm-gui
     PRIVATE
-        Qt6::Gui
+        Qt6::Quick
+        Qt6::QuickControls2
 )

--- a/apps/hasm-gui/src/main.cpp
+++ b/apps/hasm-gui/src/main.cpp
@@ -1,10 +1,19 @@
 #include <QGuiApplication>
+#include <QQmlApplicationEngine>
 
 #include <cstdlib>
 
 int main( int argc, char* argv[] )
 {
-    const QGuiApplication app( argc, argv );
+    QGuiApplication       app( argc, argv );
+    QQmlApplicationEngine engine;
 
-    return EXIT_SUCCESS;
+    engine.loadFromModule( "Hasm", "Main" );
+
+    if ( engine.rootObjects().isEmpty() )
+    {
+        return EXIT_FAILURE;
+    }
+
+    return QGuiApplication::exec();
 }

--- a/apps/hasm-gui/src/main.cpp
+++ b/apps/hasm-gui/src/main.cpp
@@ -1,0 +1,10 @@
+#include <QGuiApplication>
+
+#include <cstdlib>
+
+int main( int argc, char* argv[] )
+{
+    const QGuiApplication app( argc, argv );
+
+    return EXIT_SUCCESS;
+}

--- a/apps/hasm-gui/src/qml/Main.qml
+++ b/apps/hasm-gui/src/qml/Main.qml
@@ -1,0 +1,17 @@
+import QtQuick
+import QtQuick.Controls
+
+ApplicationWindow {
+    width: 400
+    height: 300
+
+    visible: true
+
+    title: qsTr("hasm")
+
+    Label {
+        anchors.centerIn: parent
+
+        text: qsTr("hello there!")
+    }
+}


### PR DESCRIPTION
## Summary

A Qt 6-based GUI app called `hasm-gui` is added to the project. Right now, it shows a minimal Qml window. CI has been updated to make sure Qt is installed and available in the system (so `find_package` can find it).
